### PR TITLE
[Xcode 8] Fix SecRandomCopyBytes ignoring return warning

### DIFF
--- a/AdyenCSE/Classes/ADYCryptor.m
+++ b/AdyenCSE/Classes/ADYCryptor.m
@@ -36,11 +36,15 @@ static NSUInteger crypt_ivLength = 12;
 {
     // generate a unique AES key and (later) encrypt it with the public RSA key of the merchant
     NSMutableData *key = [NSMutableData dataWithLength:kCCKeySizeAES256];
-    SecRandomCopyBytes(NULL, kCCKeySizeAES256, key.mutableBytes);
+    if (SecRandomCopyBytes(NULL, kCCKeySizeAES256, key.mutableBytes) != 0) {
+        return nil;
+    }
     
     // generate a nonce
     NSMutableData *iv = [NSMutableData dataWithLength:crypt_ivLength];
-    SecRandomCopyBytes(NULL, crypt_ivLength, iv.mutableBytes);
+    if (SecRandomCopyBytes(NULL, crypt_ivLength, iv.mutableBytes) != 0) {
+        return nil;
+    }
     
     NSData *cipherText = [self aesEncrypt:data withKey:key iv:iv];
     


### PR DESCRIPTION
Hi,

Xcode 8 is generating a warning because the `SecRandomCopyBytes` function is now marked as `__attribute__ ((warn_unused_result))`

<img width="244" alt="warn_unused_result" src="https://cloud.githubusercontent.com/assets/868749/19111854/05ca4408-8b02-11e6-8b4e-de359d5e3a93.png">

<img width="513" alt="warn_unused_result2" src="https://cloud.githubusercontent.com/assets/868749/19111949/77c38a88-8b02-11e6-83f1-02cac8f24352.png">

So I have updated the code to catch the result and return nil if the call failed.

Cheers,

Vincent
