### PR TITLE
Update AdyenCSE.podspec

### DIFF
--- a/AdyenCSE.podspec
+++ b/AdyenCSE.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.author                  = { 'Adyen' => 'support@adyen.com' }
   s.source                  = { :git => 'https://github.com/Adyen/AdyenCSE-iOS.git', :tag => "#{s.version}" }
   s.ios.deployment_target   = '7.0'
-  s.source_files            = 'AdyenCSE/**/*'
+  s.source_files            = 'AdyenCSE/**/*.{h,m}'
   s.frameworks              = 'Foundation', 'Security'
 end


### PR DESCRIPTION
Fixes Podspec to only include h/m files. This ensures compatibility with Xcode 9s 'New Build System'. 